### PR TITLE
Fixed Cargo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.1
+Fixed Cargo support.
+
 # 0.1.0
 Now we support Cargo!
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,11 +3,11 @@ module.exports =
     executablePath:
       type: 'string'
       default: 'rustc'
-      description: 'Path to rust compiler'
-    executablePath2:
+      description: 'Path to rust compiler (rustc)'
+    cargoPath:
       type: 'string'
       default: 'cargo'
-      description: 'Path to rust package manager'
+      description: 'Path to rust package manager (cargo)'
 
   activate: ->
     console.log 'Linter-Rust: package loaded,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lint Rust on the fly, using rustc and cargo",
   "repository": "https://github.com/AtomLinter/linter-rust",
   "license": "MIT",


### PR DESCRIPTION
Hi!
I've tried to fix the linter to work with the latest Rust nightly & bundled cargo: 

```
Linter-Rust: found cargo 0.0.1-pre-nightly (3f74d7e 2015-02-14) (built 2015-02-13)
Linter-Rust: found rustc 1.0.0-nightly (b9ba643b7 2015-02-13 21:15:39 +0000)
```

It works fine currently for me with cargo (e.g.: the [tutorial](http://doc.rust-lang.org/intro.html)) on save - it would be nice to add unsaved files support too, but that's a different story altogether. :)
